### PR TITLE
fix(trj_rmsd): fix RMSF xticks/labels count mismatch with newer matplotlib

### DIFF
--- a/scripts/trj_rmsd.py
+++ b/scripts/trj_rmsd.py
@@ -108,12 +108,10 @@ def main():
             plt.xlabel("time (ns)")
         else:  # assume RMSF
             plt.plot(res)
-            n = np.linspace(0, len(res), 10)
-            plt.xticks(
-                n,
-                [a.resnum for a in rmsd_Atoms[:: int(len(res) / 10)]],
-                rotation="vertical",
-            )
+            step = max(1, int(len(res) / 10))
+            tick_indices = list(range(0, len(res), step))
+            tick_labels = [rmsd_Atoms[i].resnum for i in tick_indices]
+            plt.xticks(tick_indices, tick_labels, rotation="vertical")
             plt.xlabel("atom index")
         plt.ylabel(f"{mode.upper()} (Å)")
         plt.savefig(out)


### PR DESCRIPTION
## Problem

After updating Schrodinger (2025-3, internal Python 3.11 + matplotlib 3.x), running `trj_rmsd.py -mode RMSF -p` raises:

```
ValueError: The number of FixedLocator locations (10), usually from a call to set_ticks,
does not match the number of ticklabels (11).
```

## Root cause

`np.linspace(0, len(res), 10)` produces **10** tick positions, but `rmsd_Atoms[::int(len(res)/10)]` produces **11** elements because Python slicing includes every index that fits the step, covering both endpoints.

Older matplotlib silently accepted mismatched lengths; newer versions enforce strict equality.

## Fix

Replace the linspace/slice approach with an explicit `range()`-based calculation so that `tick_indices` and `tick_labels` are always the same length. A `max(1, ...)` guard also prevents a zero-step if `res` has fewer than 10 elements.

```python
step = max(1, int(len(res) / 10))
tick_indices = list(range(0, len(res), step))
tick_labels = [rmsd_Atoms[i].resnum for i in tick_indices]
plt.xticks(tick_indices, tick_labels, rotation="vertical")
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)